### PR TITLE
ci: fix docker options in Phase 1 workflow

### DIFF
--- a/.github/workflows/ci-phase1.yml
+++ b/.github/workflows/ci-phase1.yml
@@ -18,9 +18,9 @@ jobs:
           POSTGRES_DB: selfos_dev
         ports: ["5432:5432"]
         options: >-
-          --health-cmd "pg_isready -U selfos" \
-          --health-interval 10s \
-          --health-timeout 5s \
+          --health-cmd "pg_isready -U selfos"
+          --health-interval 10s
+          --health-timeout 5s
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
@@ -70,4 +70,3 @@ jobs:
             s.add(u); s.commit()
           print('OK')
           PY
-


### PR DESCRIPTION
Fixes the GitHub Actions 'services' options formatting by removing shell backslashes, which caused 'invalid reference format' during docker create.\n\nThis should make the 'CI Phase 1 (DB & Migrations)' check pass on PR #15.