### PR TITLE
ci: fix PR workflow stability (wait and auth)

### DIFF
--- a/.github/workflows/ci-phase1.yml
+++ b/.github/workflows/ci-phase1.yml
@@ -26,12 +26,16 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Postgres client
         run: sudo apt-get update && sudo apt-get install -y postgresql-client
-      - name: Wait for Postgres
+      - name: Wait for Postgres (psql)
+        env:
+          PSQL_DSN: postgresql://selfos:selfos@127.0.0.1:5432/selfos_dev
         run: |
-          for i in {1..20}; do
-            if pg_isready -h 127.0.0.1 -p 5432 -U selfos; then exit 0; fi
+          for i in {1..30}; do
+            if psql "$PSQL_DSN" -c 'SELECT 1' >/dev/null 2>&1; then
+              echo "Postgres is ready"; exit 0; fi
             sleep 2
           done
+          echo "Postgres did not become ready in time" >&2
           exit 1
       - name: Enable pgvector
         run: psql "postgresql://selfos:selfos@127.0.0.1:5432/selfos_dev" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION IF NOT EXISTS vector;"

--- a/.github/workflows/ci-phase1.yml
+++ b/.github/workflows/ci-phase1.yml
@@ -24,6 +24,8 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
+      - name: Install Postgres client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
       - name: Wait for Postgres
         run: |
           for i in {1..20}; do
@@ -31,10 +33,8 @@ jobs:
             sleep 2
           done
           exit 1
-      - name: Install Postgres client
-        run: sudo apt-get update && sudo apt-get install -y postgresql-client
       - name: Enable pgvector
-        run: psql "host=127.0.0.1 port=5432 dbname=selfos_dev user=selfos" -c "CREATE EXTENSION IF NOT EXISTS vector;"
+        run: psql "postgresql://selfos:selfos@127.0.0.1:5432/selfos_dev" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION IF NOT EXISTS vector;"
       - name: Setup Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Improves Phase 1 CI stability:\n- Wait using psql with DSN and password (no pg_isready deps)\n- Installs psql before waiting\n- Keeps pgvector CREATE EXTENSION via DSN\n\nOnce merged, PR #15 should pass checks.