### PR TITLE
fix(models): SQLAlchemy reserved name in Memory (metadata)

### DIFF
--- a/.github/workflows/ci-phase1.yml
+++ b/.github/workflows/ci-phase1.yml
@@ -26,12 +26,16 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Postgres client
         run: sudo apt-get update && sudo apt-get install -y postgresql-client
-      - name: Wait for Postgres
+      - name: Wait for Postgres (psql)
+        env:
+          PSQL_DSN: postgresql://selfos:selfos@127.0.0.1:5432/selfos_dev
         run: |
-          for i in {1..20}; do
-            if pg_isready -h 127.0.0.1 -p 5432 -U selfos; then exit 0; fi
+          for i in {1..30}; do
+            if psql "$PSQL_DSN" -c 'SELECT 1' >/dev/null 2>&1; then
+              echo "Postgres is ready"; exit 0; fi
             sleep 2
           done
+          echo "Postgres did not become ready in time" >&2
           exit 1
       - name: Enable pgvector
         run: psql "postgresql://selfos:selfos@127.0.0.1:5432/selfos_dev" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION IF NOT EXISTS vector;"

--- a/.github/workflows/ci-phase1.yml
+++ b/.github/workflows/ci-phase1.yml
@@ -54,6 +54,7 @@ jobs:
         working-directory: apps/api
         env:
           DATABASE_URL: postgresql+psycopg://selfos:selfos@127.0.0.1:5432/selfos_dev
+          PYTHONPATH: ${{ github.workspace }}/apps/api
         run: |
           . .venv/bin/activate
           alembic -c alembic.ini upgrade head
@@ -61,6 +62,7 @@ jobs:
         working-directory: apps/api
         env:
           DATABASE_URL: postgresql+psycopg://selfos:selfos@127.0.0.1:5432/selfos_dev
+          PYTHONPATH: ${{ github.workspace }}/apps/api
         run: |
           . .venv/bin/activate
           python - <<'PY'

--- a/.github/workflows/ci-phase1.yml
+++ b/.github/workflows/ci-phase1.yml
@@ -24,6 +24,8 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
+      - name: Install Postgres client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
       - name: Wait for Postgres
         run: |
           for i in {1..20}; do
@@ -31,10 +33,8 @@ jobs:
             sleep 2
           done
           exit 1
-      - name: Install Postgres client
-        run: sudo apt-get update && sudo apt-get install -y postgresql-client
       - name: Enable pgvector
-        run: psql "host=127.0.0.1 port=5432 dbname=selfos_dev user=selfos" -c "CREATE EXTENSION IF NOT EXISTS vector;"
+        run: psql "postgresql://selfos:selfos@127.0.0.1:5432/selfos_dev" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION IF NOT EXISTS vector;"
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/apps/api/app/models/core.py
+++ b/apps/api/app/models/core.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Integer,
+    PrimaryKeyConstraint,
     String,
     Text,
     UniqueConstraint,
@@ -62,7 +63,7 @@ class LifeArea(Base, IdMixin):
 class LifeAreaLink(Base):
     __tablename__ = "life_area_links"
     __table_args__ = (
-        UniqueConstraint("life_area_id", "object_type", "object_id", name="pk_life_area_link"),
+        PrimaryKeyConstraint("life_area_id", "object_type", "object_id", name="pk_life_area_link"),
         Index("ix_lal_user_object", "user_id", "object_type", "object_id"),
         CheckConstraint("object_type in ('dream','goal','project','task','habit')", name="ck_lal_object_type"),
         {"schema": "core"},
@@ -168,4 +169,3 @@ class Attachment(Base, IdMixin):
     gcs_path = Column(String, nullable=False)
     mime = Column(String, nullable=False)
     size_bytes = Column(Integer, nullable=True)
-

--- a/apps/api/app/models/memory.py
+++ b/apps/api/app/models/memory.py
@@ -15,6 +15,7 @@ class Memory(Base):
     user_id = Column(String, nullable=False)  # schema-agnostic; reference core.users.id in app logic
     text = Column(String, nullable=False)
     # embedding stored via pgvector; managed in migration as raw SQL
-    metadata = Column(JSONB, nullable=False, default=dict)
+    # 'metadata' is a reserved attribute name in SQLAlchemy declarative Base.
+    # Map the DB column named "metadata" to a Python attribute named "meta".
+    meta = Column("metadata", JSONB, nullable=False, default=dict)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
-


### PR DESCRIPTION
Maps the database column 'metadata' to Python attribute 'meta' in the Memory model to avoid SQLAlchemy's reserved Base.metadata collision.\n\nThis should resolve the InvalidRequestError during Alembic import in the Phase 1 CI.\n\nAfter merging this along with #21 (PYTHONPATH) and #22 (LifeAreaLink PK), PR #15 checks should pass.