### PR TITLE
ci: ensure schema for ORM & diff jobs (upgrade head)

### DIFF
--- a/.github/workflows/build-db-ci.yml
+++ b/.github/workflows/build-db-ci.yml
@@ -191,6 +191,14 @@ jobs:
           . .venv/bin/activate
           pip install -U pip
           pip install -r requirements.txt
+      - name: Alembic upgrade (prepare schema)
+        working-directory: apps/api
+        env:
+          DATABASE_URL: postgresql+psycopg://selfos:selfos@127.0.0.1:5432/selfos_dev
+          PYTHONPATH: ${{ github.workspace }}/apps/api
+        run: |
+          . .venv/bin/activate
+          alembic -c alembic.ini upgrade head
       - name: Smoke insert
         working-directory: apps/api
         env:
@@ -256,6 +264,14 @@ jobs:
           . .venv/bin/activate
           pip install -U pip
           pip install -r requirements.txt
+      - name: Alembic upgrade (prepare schema)
+        working-directory: apps/api
+        env:
+          DATABASE_URL: postgresql+psycopg://selfos:selfos@127.0.0.1:5432/selfos_dev
+          PYTHONPATH: ${{ github.workspace }}/apps/api
+        run: |
+          . .venv/bin/activate
+          alembic -c alembic.ini upgrade head
       - name: Autogenerate must be empty
         working-directory: apps/api
         env:
@@ -269,4 +285,3 @@ jobs:
             echo "Schema drift: autogenerate created a new revision" >&2
             exit 1
           fi
-

--- a/.github/workflows/build-db-ci.yml
+++ b/.github/workflows/build-db-ci.yml
@@ -1,0 +1,272 @@
+name: Build & DB CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main, dev/phase1 ]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  migrations-up:
+    name: Alembic upgrade (matrix ${{ matrix.pg }})
+    strategy:
+      matrix:
+        pg: [pg14, pg15]
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:${{ matrix.pg }}
+        env:
+          POSTGRES_USER: selfos
+          POSTGRES_PASSWORD: selfos
+          POSTGRES_DB: selfos_dev
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd "pg_isready -U selfos"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Postgres client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+      - name: Wait for Postgres
+        env:
+          DSN: postgresql://selfos:selfos@127.0.0.1:5432/selfos_dev
+        run: |
+          for i in {1..40}; do psql "$DSN" -c 'SELECT 1' >/dev/null 2>&1 && exit 0; sleep 2; done; exit 1
+      - name: Enable pgvector
+        run: psql "postgresql://selfos:selfos@127.0.0.1:5432/selfos_dev" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION IF NOT EXISTS vector;"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('apps/api/requirements.txt') }}
+      - name: Install deps
+        working-directory: apps/api
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          pip install -U pip
+          pip install -r requirements.txt
+      - name: Alembic upgrade
+        working-directory: apps/api
+        env:
+          DATABASE_URL: postgresql+psycopg://selfos:selfos@127.0.0.1:5432/selfos_dev
+          PYTHONPATH: ${{ github.workspace }}/apps/api
+        run: |
+          . .venv/bin/activate
+          alembic -c alembic.ini upgrade head
+
+  migrations-downgrade-up:
+    name: Alembic downgrade->upgrade
+    needs: migrations-up
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: selfos
+          POSTGRES_PASSWORD: selfos
+          POSTGRES_DB: selfos_dev
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd "pg_isready -U selfos"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Postgres client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+      - name: Wait for Postgres
+        env:
+          DSN: postgresql://selfos:selfos@127.0.0.1:5432/selfos_dev
+        run: |
+          for i in {1..40}; do psql "$DSN" -c 'SELECT 1' >/dev/null 2>&1 && exit 0; sleep 2; done; exit 1
+      - name: Enable pgvector
+        run: psql "postgresql://selfos:selfos@127.0.0.1:5432/selfos_dev" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION IF NOT EXISTS vector;"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('apps/api/requirements.txt') }}
+      - name: Install deps
+        working-directory: apps/api
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          pip install -U pip
+          pip install -r requirements.txt
+      - name: Alembic downgrade->upgrade
+        working-directory: apps/api
+        env:
+          DATABASE_URL: postgresql+psycopg://selfos:selfos@127.0.0.1:5432/selfos_dev
+          PYTHONPATH: ${{ github.workspace }}/apps/api
+        run: |
+          . .venv/bin/activate
+          alembic -c alembic.ini downgrade base
+          alembic -c alembic.ini upgrade head
+
+  orm-import:
+    name: ORM import check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('apps/api/requirements.txt') }}
+      - name: Install deps
+        working-directory: apps/api
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          pip install -U pip
+          pip install -r requirements.txt
+      - name: Import models
+        working-directory: apps/api
+        env:
+          PYTHONPATH: ${{ github.workspace }}/apps/api
+        run: |
+          . .venv/bin/activate
+          python - <<'PY'
+          from app.models import *  # noqa: F401,F403
+          print('Models import OK')
+          PY
+
+  orm-smoke:
+    name: ORM smoke insert
+    needs: migrations-up
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: selfos
+          POSTGRES_PASSWORD: selfos
+          POSTGRES_DB: selfos_dev
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd "pg_isready -U selfos"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Postgres client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+      - name: Wait for Postgres
+        env:
+          DSN: postgresql://selfos:selfos@127.0.0.1:5432/selfos_dev
+        run: |
+          for i in {1..40}; do psql "$DSN" -c 'SELECT 1' >/dev/null 2>&1 && exit 0; sleep 2; done; exit 1
+      - name: Enable pgvector
+        run: psql "postgresql://selfos:selfos@127.0.0.1:5432/selfos_dev" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION IF NOT EXISTS vector;"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('apps/api/requirements.txt') }}
+      - name: Install deps
+        working-directory: apps/api
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          pip install -U pip
+          pip install -r requirements.txt
+      - name: Smoke insert
+        working-directory: apps/api
+        env:
+          DATABASE_URL: postgresql+psycopg://selfos:selfos@127.0.0.1:5432/selfos_dev
+          PYTHONPATH: ${{ github.workspace }}/apps/api
+        run: |
+          . .venv/bin/activate
+          python - <<'PY'
+          from sqlalchemy.orm import Session
+          from sqlalchemy import create_engine
+          from app.models.core import User, LifeArea, Task
+          engine = create_engine('${{ env.DATABASE_URL }}', future=True)
+          with Session(engine) as s:
+              u = User(email='ci@example.com')
+              s.add(u); s.flush()
+              la = LifeArea(user_id=u.id, name='Health')
+              s.add(la); s.flush()
+              t = Task(user_id=u.id, title='Test task')
+              s.add(t); s.commit()
+          print('ORM smoke OK')
+          PY
+
+  alembic-diff-check:
+    name: Alembic autogenerate diff check
+    needs: migrations-up
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: selfos
+          POSTGRES_PASSWORD: selfos
+          POSTGRES_DB: selfos_dev
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd "pg_isready -U selfos"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Postgres client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+      - name: Wait for Postgres
+        env:
+          DSN: postgresql://selfos:selfos@127.0.0.1:5432/selfos_dev
+        run: |
+          for i in {1..40}; do psql "$DSN" -c 'SELECT 1' >/dev/null 2>&1 && exit 0; sleep 2; done; exit 1
+      - name: Enable pgvector
+        run: psql "postgresql://selfos:selfos@127.0.0.1:5432/selfos_dev" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION IF NOT EXISTS vector;"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('apps/api/requirements.txt') }}
+      - name: Install deps
+        working-directory: apps/api
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          pip install -U pip
+          pip install -r requirements.txt
+      - name: Autogenerate must be empty
+        working-directory: apps/api
+        env:
+          DATABASE_URL: postgresql+psycopg://selfos:selfos@127.0.0.1:5432/selfos_dev
+          PYTHONPATH: ${{ github.workspace }}/apps/api
+        run: |
+          . .venv/bin/activate
+          rm -f alembic/versions/_tmp_*.py
+          alembic -c alembic.ini revision --autogenerate -m "_tmp_check" || true
+          if ls alembic/versions/_tmp_*.py 1> /dev/null 2>&1; then
+            echo "Schema drift: autogenerate created a new revision" >&2
+            exit 1
+          fi
+

--- a/.github/workflows/ci-phase1.yml
+++ b/.github/workflows/ci-phase1.yml
@@ -26,12 +26,16 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Postgres client
         run: sudo apt-get update && sudo apt-get install -y postgresql-client
-      - name: Wait for Postgres
+      - name: Wait for Postgres (psql)
+        env:
+          PSQL_DSN: postgresql://selfos:selfos@127.0.0.1:5432/selfos_dev
         run: |
-          for i in {1..20}; do
-            if pg_isready -h 127.0.0.1 -p 5432 -U selfos; then exit 0; fi
+          for i in {1..30}; do
+            if psql "$PSQL_DSN" -c 'SELECT 1' >/dev/null 2>&1; then
+              echo "Postgres is ready"; exit 0; fi
             sleep 2
           done
+          echo "Postgres did not become ready in time" >&2
           exit 1
       - name: Enable pgvector
         run: psql "postgresql://selfos:selfos@127.0.0.1:5432/selfos_dev" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION IF NOT EXISTS vector;"

--- a/.github/workflows/ci-phase1.yml
+++ b/.github/workflows/ci-phase1.yml
@@ -54,6 +54,7 @@ jobs:
         working-directory: apps/api
         env:
           DATABASE_URL: postgresql+psycopg://selfos:selfos@127.0.0.1:5432/selfos_dev
+          PYTHONPATH: ${{ github.workspace }}/apps/api
         run: |
           . .venv/bin/activate
           alembic -c alembic.ini upgrade head
@@ -61,6 +62,7 @@ jobs:
         working-directory: apps/api
         env:
           DATABASE_URL: postgresql+psycopg://selfos:selfos@127.0.0.1:5432/selfos_dev
+          PYTHONPATH: ${{ github.workspace }}/apps/api
         run: |
           . .venv/bin/activate
           python - <<'PY'

--- a/.github/workflows/ci-phase1.yml
+++ b/.github/workflows/ci-phase1.yml
@@ -24,6 +24,8 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
+      - name: Install Postgres client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
       - name: Wait for Postgres
         run: |
           for i in {1..20}; do
@@ -31,10 +33,8 @@ jobs:
             sleep 2
           done
           exit 1
-      - name: Install Postgres client
-        run: sudo apt-get update && sudo apt-get install -y postgresql-client
       - name: Enable pgvector
-        run: psql "host=127.0.0.1 port=5432 dbname=selfos_dev user=selfos" -c "CREATE EXTENSION IF NOT EXISTS vector;"
+        run: psql "postgresql://selfos:selfos@127.0.0.1:5432/selfos_dev" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION IF NOT EXISTS vector;"
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/apps/api/app/models/core.py
+++ b/apps/api/app/models/core.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Integer,
+    PrimaryKeyConstraint,
     String,
     Text,
     UniqueConstraint,
@@ -62,7 +63,7 @@ class LifeArea(Base, IdMixin):
 class LifeAreaLink(Base):
     __tablename__ = "life_area_links"
     __table_args__ = (
-        UniqueConstraint("life_area_id", "object_type", "object_id", name="pk_life_area_link"),
+        PrimaryKeyConstraint("life_area_id", "object_type", "object_id", name="pk_life_area_link"),
         Index("ix_lal_user_object", "user_id", "object_type", "object_id"),
         CheckConstraint("object_type in ('dream','goal','project','task','habit')", name="ck_lal_object_type"),
         {"schema": "core"},
@@ -168,4 +169,3 @@ class Attachment(Base, IdMixin):
     gcs_path = Column(String, nullable=False)
     mime = Column(String, nullable=False)
     size_bytes = Column(Integer, nullable=True)
-

--- a/apps/api/app/models/core.py
+++ b/apps/api/app/models/core.py
@@ -21,10 +21,10 @@ from ..db import Base
 
 
 def ulid() -> str:
-    # Runtime dependency provided via ulid-py
-    from ulid import ULID
+    # Use ulid-py factory to generate a new ULID string
+    import ulid as _ulid
 
-    return str(ULID())
+    return _ulid.new().str
 
 
 @declarative_mixin

--- a/apps/api/app/models/memory.py
+++ b/apps/api/app/models/memory.py
@@ -15,6 +15,7 @@ class Memory(Base):
     user_id = Column(String, nullable=False)  # schema-agnostic; reference core.users.id in app logic
     text = Column(String, nullable=False)
     # embedding stored via pgvector; managed in migration as raw SQL
-    metadata = Column(JSONB, nullable=False, default=dict)
+    # 'metadata' is a reserved attribute name in SQLAlchemy declarative Base.
+    # Map the DB column named "metadata" to a Python attribute named "meta".
+    meta = Column("metadata", JSONB, nullable=False, default=dict)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
-


### PR DESCRIPTION
Extends Build & DB CI so that jobs using ORM or autogenerate first run Alembic upgrade head:\n- orm-smoke: create schema before inserts\n- alembic-diff-check: compare models to head schema\n\nThis fixes 'relation core.users does not exist' in ORM job.