### PR TITLE
Phase2 CI fixes: export_openapi + npm install

### DIFF
--- a/.github/workflows/api-web-ci.yml
+++ b/.github/workflows/api-web-ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Export OpenAPI
         working-directory: apps/api
         run: |
-          ./scripts/export_openapi.sh > /dev/null
+          bash ./scripts/export_openapi.sh
       - uses: actions/upload-artifact@v4
         with:
           name: openapi.json
@@ -56,7 +56,7 @@ jobs:
           cache-dependency-path: apps/web/package.json
       - name: Install web deps
         working-directory: apps/web
-        run: npm ci
+        run: npm install
       - name: Lint
         working-directory: apps/web
         run: npm run lint -- --no-error-on-unmatched-pattern
@@ -65,4 +65,3 @@ jobs:
         env:
           NEXT_PUBLIC_API_BASE_URL: http://localhost:8000
         run: npm run build
-

--- a/apps/api/scripts/export_openapi.sh
+++ b/apps/api/scripts/export_openapi.sh
@@ -13,13 +13,15 @@ if curl -fsS "http://$HOST:$PORT/openapi.json" >/dev/null 2>&1; then
   exit 0
 fi
 
-echo "[+] Launching uvicorn to export OpenAPI..."
+echo "[+] Generating OpenAPI without server..."
 pushd "$(dirname "$0")/.." >/dev/null
-python - <<'PY'
+PYBIN="python3"
+if [ -x .venv/bin/python ]; then PYBIN=".venv/bin/python"; fi
+"$PYBIN" - <<'PY' > "$OUT"
 import json
 from app.api.main import create_app
 app = create_app()
 print(json.dumps(app.openapi()))
 PY
+echo "[✓] OpenAPI written to $OUT"
 popd >/dev/null
-


### PR DESCRIPTION
Fixes Phase 2 CI:\n- export_openapi.sh now writes to OUT using venv python if present\n- CI runs the script via bash (no exec bit needed)\n- Web job uses npm install (lockfile not required)\n\nMerging this into dev/phase2 should make API & Web CI pass.