### PR TITLE
web: upgrade to Next 15 + eslint-config-next 15 (align ESLint 9/TS 5.6)

### DIFF
--- a/.github/workflows/api-web-ci.yml
+++ b/.github/workflows/api-web-ci.yml
@@ -3,7 +3,7 @@ name: API & Web CI
 on:
   pull_request:
   push:
-    branches: [ dev/phase2 ]
+    branches: [ dev/phase2, dev/phase2-ci-fixes ]
 
 jobs:
   api:

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.55.4",
-    "next": "^14.2.15",
+    "next": "^15.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
@@ -18,9 +18,8 @@
     "@types/node": "^20.14.8",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "eslint": "^9.10.0",
-    "eslint-config-next": "^14.2.15",
-    "typescript": "^5.5.4"
+    "eslint": "^9.36.0",
+    "eslint-config-next": "^15.0.0",
+    "typescript": "^5.6.3"
   }
 }
-


### PR DESCRIPTION
Upgrades web toolchain to resolve npm ERESOLVE:\n- next: ^15\n- eslint: ^9\n- eslint-config-next: ^15\n- typescript: ^5.6\n\nThis PR targets dev/phase2-ci-fixes (not main), so merging it will update PR #28 (dev/phase2-ci-fixes → dev/phase2).